### PR TITLE
PeSTO Evaluation Function

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -1,6 +1,6 @@
 use crate::pieces::{Piece, Color, PIECE_COUNT, COLOR_COUNT, PieceIterator, ColorIterator};
-use crate::square::{Square, A1, D1, F1, G1, H1, A8, D8, F8, G8, H8, square_to_algebraic};
-use crate::bitboard::{Bitboard, BitboardOperations, WHITE_QUEEN_SIDE, WHITE_KING_SIDE, BLACK_QUEEN_SIDE, BLACK_KING_SIDE};
+use crate::square::{Square, A1, D1, F1, G1, H1, A8, D8, F8, G8, H8};
+use crate::bitboard::{Bitboard, BitboardOperations};
 use crate::util::print_bitboard;
 use crate::fen::fen_to_board;
 use crate::moves::{Move, MoveType};
@@ -104,8 +104,7 @@ impl Board {
             MoveType::Capture => self.make_capture(mv),
             MoveType::EnPassant => self.make_en_passant(mv),
             MoveType::Castle => self.make_castle(mv),
-            MoveType::Promotion => self.make_promotion(mv),
-            _ => {}
+            MoveType::Promotion => self.make_promotion(mv)
         }
 
         self.change_color();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,152 +1,46 @@
+use std::time::Instant;
 use crate::board::Board;
 use crate::bitboard::{SQUARES, BitboardIterator};
 use crate::pieces::{Piece, Color, PIECE_COUNT, PieceIterator};
 
 type PST = [i32; SQUARES as usize];
 
-const OPENING_PAWN_TABLE: PST = [
-      0,   0,   0,   0,   0,   0,  0,   0,
-     98, 134,  61,  95,  68, 126, 34, -11,
-     -6,   7,  26,  31,  65,  56, 25, -20,
-    -14,  13,   6,  21,  23,  12, 17, -23,
-    -27,  -2,  -5,  12,  17,   6, 10, -25,
-    -26,  -4,  -4, -10,   3,   3, 33, -12,
-    -35,  -1, -20, -23, -15,  24, 38, -22,
-      0,   0,   0,   0,   0,   0,  0,   0,
+const OPENING_TABLES: [PST; PIECE_COUNT] = [
+    // Pawn (82 + positional)
+    [82, 82, 82, 82, 82, 82, 82, 82, 180, 216, 143, 177, 150, 208, 116, 71, 76, 89, 108, 113, 147, 138, 107, 62, 68, 95, 88, 103, 105, 94, 99, 59, 55, 80, 77, 94, 99, 88, 92, 57, 56, 78, 78, 72, 85, 85, 115, 70, 47, 81, 62, 59, 67, 106, 120, 60, 82, 82, 82, 82, 82, 82, 82, 82],
+    // Knight (337 + positional)
+    [170, 248, 303, 288, 398, 240, 322, 230, 264, 296, 409, 373, 360, 399, 344, 320, 290, 397, 374, 402, 421, 466, 410, 381, 328, 354, 356, 390, 374, 406, 355, 359, 324, 341, 353, 350, 365, 356, 358, 329, 314, 328, 349, 347, 356, 354, 362, 321, 308, 284, 325, 334, 336, 355, 323, 318, 232, 316, 279, 304, 320, 309, 318, 314],
+    // Bishop (365 + positional)
+    [336, 369, 283, 328, 340, 323, 372, 357, 339, 381, 347, 352, 395, 424, 383, 318, 349, 402, 408, 405, 400, 415, 402, 363, 361, 370, 384, 415, 402, 402, 372, 363, 359, 378, 378, 391, 399, 377, 375, 369, 365, 380, 380, 380, 379, 392, 383, 375, 369, 380, 381, 365, 372, 386, 398, 366, 332, 362, 351, 344, 352, 353, 326, 344],
+    // Rook (477 + positional)
+    [509, 519, 509, 528, 540, 486, 508, 520, 504, 509, 535, 539, 557, 544, 503, 521, 472, 496, 503, 513, 494, 522, 538, 493, 453, 466, 484, 503, 501, 512, 469, 457, 441, 451, 465, 476, 486, 470, 483, 454, 432, 452, 461, 460, 480, 477, 472, 444, 433, 461, 457, 468, 476, 488, 471, 406, 458, 464, 478, 494, 493, 484, 440, 451],
+    // Queen (1025 + positional)
+    [997, 1025, 1054, 1037, 1084, 1069, 1068, 1070, 1001, 986, 1020, 1026, 1009, 1082, 1053, 1079, 1012, 1008, 1032, 1033, 1054, 1081, 1072, 1082, 998, 998, 1009, 1009, 1024, 1042, 1023, 1026, 1016, 999, 1016, 1015, 1023, 1021, 1028, 1022, 1011, 1027, 1014, 1023, 1020, 1027, 1039, 1030, 990, 1017, 1036, 1027, 1033, 1040, 1022, 1026, 1024, 1007, 1016, 1035, 1010, 1000, 994, 975],
+    // King (0 + positional)
+    [-65, 23, 16, -15, -56, -34, 2, 13, 29, -1, -20, -7, -8, -4, -38, -29, -9, 24, 2, -16, -20, 6, 22, -22, -17, -20, -12, -27, -30, -25, -14, -36, -49, -1, -27, -39, -46, -44, -33, -51, -14, -14, -22, -46, -44, -30, -15, -27, 1, 7, -8, -64, -43, -16, 9, 8, -15, 36, 12, -54, 8, -28, 24, 14],
 ];
 
-const ENDGAME_PAWN_TABLE: PST = [
-      0,   0,   0,   0,   0,   0,   0,   0,
-    178, 173, 158, 134, 147, 132, 165, 187,
-     94, 100,  85,  67,  56,  53,  82,  84,
-     32,  24,  13,   5,  -2,   4,  17,  17,
-     13,   9,  -3,  -7,  -7,  -8,   3,  -1,
-      4,   7,  -6,   1,   0,  -5,  -1,  -8,
-     13,   8,   8,  10,  13,   0,   2,  -7,
-      0,   0,   0,   0,   0,   0,   0,   0,
+const ENDGAME_TABLES: [PST; PIECE_COUNT] = [
+    // Pawn (94 + positional)
+    [94, 94, 94, 94, 94, 94, 94, 94, 272, 267, 252, 228, 241, 226, 259, 281, 188, 194, 179, 161, 150, 147, 176, 178, 126, 118, 107, 99, 92, 98, 111, 111, 107, 103, 91, 87, 87, 86, 97, 93, 98, 101, 88, 95, 94, 89, 93, 86, 107, 102, 102, 104, 107, 94, 96, 87, 94, 94, 94, 94, 94, 94, 94, 94],
+    // Knight (281 + positional)
+    [223, 243, 268, 253, 250, 254, 218, 182, 256, 273, 256, 279, 272, 256, 257, 229, 257, 261, 291, 290, 280, 272, 262, 240, 264, 284, 303, 303, 303, 292, 289, 263, 263, 275, 297, 306, 297, 298, 285, 263, 258, 278, 280, 296, 291, 278, 261, 259, 239, 261, 271, 276, 279, 261, 258, 237, 252, 230, 258, 266, 259, 263, 231, 217],
+    // Bishop (297 + positional)
+    [283, 276, 286, 289, 290, 288, 280, 273, 289, 293, 304, 285, 294, 284, 293, 283, 299, 289, 297, 296, 295, 303, 297, 301, 294, 306, 309, 306, 311, 307, 300, 299, 291, 300, 310, 316, 304, 307, 294, 288, 285, 294, 305, 307, 310, 300, 290, 282, 283, 279, 290, 296, 301, 288, 282, 270, 274, 288, 274, 292, 288, 281, 292, 280],
+    // Rook (512 + positional)
+    [525, 522, 530, 527, 524, 524, 520, 517, 523, 525, 525, 523, 509, 515, 520, 515, 519, 519, 519, 517, 516, 509, 507, 509, 516, 515, 525, 513, 514, 513, 511, 514, 515, 517, 520, 516, 507, 506, 504, 501, 508, 512, 507, 511, 505, 500, 504, 496, 506, 506, 512, 514, 503, 503, 501, 509, 503, 514, 515, 511, 507, 499, 516, 492],
+    // Queen (936 + positional)
+    [927, 958, 958, 963, 963, 955, 946, 956, 919, 956, 968, 977, 994, 961, 966, 936, 916, 942, 945, 985, 983, 971, 955, 945, 939, 958, 960, 981, 993, 976, 993, 972, 918, 964, 955, 983, 967, 970, 975, 959, 920, 909, 951, 942, 945, 953, 946, 941, 914, 913, 906, 920, 920, 913, 900, 904, 903, 908, 914, 893, 931, 904, 916, 895],
+    // King (0 + positional)
+    [-74, -35, -18, -18, -11, 15, 4, -17, -12, 17, 14, 17, 17, 38, 23, 11, 10, 17, 23, 15, 20, 45, 44, 13, -8, 22, 24, 27, 26, 33, 26, 3, -18, -4, 21, 24, 27, 23, 9, -11, -19, -3, 11, 21, 23, 16, 7, -9, -27, -11, 4, 13, 14, 4, -5, -17, -53, -34, -21, -11, -28, -14, -24, -43],
 ];
 
-const OPENING_KNIGHT_TABLE: PST = [
-    -167, -89, -34, -49,  61, -97, -15, -107,
-     -73, -41,  72,  36,  23,  62,   7,  -17,
-     -47,  60,  37,  65,  84, 129,  73,   44,
-      -9,  17,  19,  53,  37,  69,  18,   22,
-     -13,   4,  16,  13,  28,  19,  21,   -8,
-     -23,  -9,  12,  10,  19,  17,  25,  -16,
-     -29, -53, -12,  -3,  -1,  18, -14,  -19,
-    -105, -21, -58, -33, -17, -28, -19,  -23,
-];
-
-const ENDGAME_KNIGHT_TABLE: PST = [
-    -58, -38, -13, -28, -31, -27, -63, -99,
-    -25,  -8, -25,  -2,  -9, -25, -24, -52,
-    -24, -20,  10,   9,  -1,  -9, -19, -41,
-    -17,   3,  22,  22,  22,  11,   8, -18,
-    -18,  -6,  16,  25,  16,  17,   4, -18,
-    -23,  -3,  -1,  15,  10,  -3, -20, -22,
-    -42, -20, -10,  -5,  -2, -20, -23, -44,
-    -29, -51, -23, -15, -22, -18, -50, -64,
-];
-
-const OPENING_BISHOP_TABLE: PST = [
-    -29,   4, -82, -37, -25, -42,   7,  -8,
-    -26,  16, -18, -13,  30,  59,  18, -47,
-    -16,  37,  43,  40,  35,  50,  37,  -2,
-     -4,   5,  19,  50,  37,  37,   7,  -2,
-     -6,  13,  13,  26,  34,  12,  10,   4,
-      0,  15,  15,  15,  14,  27,  18,  10,
-      4,  15,  16,   0,   7,  21,  33,   1,
-    -33,  -3, -14, -21, -13, -12, -39, -21,
-];
-
-const ENDGAME_BISHOP_TABLE: PST = [
-    -14, -21, -11,  -8, -7,  -9, -17, -24,
-     -8,  -4,   7, -12, -3, -13,  -4, -14,
-      2,  -8,   0,  -1, -2,   6,   0,   4,
-     -3,   9,  12,   9, 14,  10,   3,   2,
-     -6,   3,  13,  19,  7,  10,  -3,  -9,
-    -12,  -3,   8,  10, 13,   3,  -7, -15,
-    -14, -18,  -7,  -1,  4,  -9, -15, -27,
-    -23,  -9, -23,  -5, -9, -16,  -5, -17,
-];
-
-const OPENING_ROOK_TABLE: PST = [
-     32,  42,  32,  51, 63,  9,  31,  43,
-     27,  32,  58,  62, 80, 67,  26,  44,
-     -5,  19,  26,  36, 17, 45,  61,  16,
-    -24, -11,   7,  26, 24, 35,  -8, -20,
-    -36, -26, -12,  -1,  9, -7,   6, -23,
-    -45, -25, -16, -17,  3,  0,  -5, -33,
-    -44, -16, -20,  -9, -1, 11,  -6, -71,
-    -19, -13,   1,  17, 16,  7, -37, -26,
-];
-
-const ENDGAME_ROOK_TABLE: PST = [
-    13, 10, 18, 15, 12,  12,   8,   5,
-    11, 13, 13, 11, -3,   3,   8,   3,
-     7,  7,  7,  5,  4,  -3,  -5,  -3,
-     4,  3, 13,  1,  2,   1,  -1,   2,
-     3,  5,  8,  4, -5,  -6,  -8, -11,
-    -4,  0, -5, -1, -7, -12,  -8, -16,
-    -6, -6,  0,  2, -9,  -9, -11,  -3,
-    -9,  2,  3, -1, -5, -13,   4, -20,
-];
-
-const OPENING_QUEEN_TABLE: PST = [
-    -28,   0,  29,  12,  59,  44,  43,  45,
-    -24, -39,  -5,   1, -16,  57,  28,  54,
-    -13, -17,   7,   8,  29,  56,  47,  57,
-    -27, -27, -16, -16,  -1,  17,  -2,   1,
-     -9, -26,  -9, -10,  -2,  -4,   3,  -3,
-    -14,   2, -11,  -2,  -5,   2,  14,   5,
-    -35,  -8,  11,   2,   8,  15,  -3,   1,
-     -1, -18,  -9,  10, -15, -25, -31, -50,
-];
-
-const ENDGAME_QUEEN_TABLE: PST = [
-     -9,  22,  22,  27,  27,  19,  10,  20,
-    -17,  20,  32,  41,  58,  25,  30,   0,
-    -20,   6,   9,  49,  47,  35,  19,   9,
-      3,  22,  24,  45,  57,  40,  57,  36,
-    -18,  28,  19,  47,  31,  34,  39,  23,
-    -16, -27,  15,   6,   9,  17,  10,   5,
-    -22, -23, -30, -16, -16, -23, -36, -32,
-    -33, -28, -22, -43,  -5, -32, -20, -41,
-];
-
-const OPENING_KING_TABLE: PST = [
-    -65,  23,  16, -15, -56, -34,   2,  13,
-     29,  -1, -20,  -7,  -8,  -4, -38, -29,
-     -9,  24,   2, -16, -20,   6,  22, -22,
-    -17, -20, -12, -27, -30, -25, -14, -36,
-    -49,  -1, -27, -39, -46, -44, -33, -51,
-    -14, -14, -22, -46, -44, -30, -15, -27,
-      1,   7,  -8, -64, -43, -16,   9,   8,
-    -15,  36,  12, -54,   8, -28,  24,  14,
-];
-
-const ENDGAME_KING_TABLE: PST = [
-    -74, -35, -18, -18, -11,  15,   4, -17,
-    -12,  17,  14,  17,  17,  38,  23,  11,
-     10,  17,  23,  15,  20,  45,  44,  13,
-     -8,  22,  24,  27,  26,  33,  26,   3,
-    -18,  -4,  21,  24,  27,  23,   9, -11,
-    -19,  -3,  11,  21,  23,  16,   7,  -9,
-    -27, -11,   4,  13,  14,   4,  -5, -17,
-    -53, -34, -21, -11, -28, -14, -24, -43
-];
-
-enum Phase {
-    Opening,
-    Endgame
-}
+const PHASE_INCREMENTS: [i32; PIECE_COUNT] = [0, 1, 1, 2, 4, 0];
 
 pub struct Evaluator {
     gamephase: i32,
     opening_score: i32,
     endgame_score: i32,
-    opening_tables: [PST; PIECE_COUNT],
-    endgame_tables: [PST; PIECE_COUNT],
 }
 
 impl Evaluator {
@@ -155,82 +49,65 @@ impl Evaluator {
             gamephase: 0,
             opening_score: 0,
             endgame_score: 0,
-            opening_tables: Self::initialize_tables(&Phase::Opening),
-            endgame_tables: Self::initialize_tables(&Phase::Endgame),
         }
     }
 
-    /// ---------------------------------------------
-    /// Functions to perform evaluation of the board
-    /// ---------------------------------------------
     pub fn evaluate(&mut self, board: &Board) -> i32 {
         self.reset();
 
         let active_color = board.active_color();
-        let piece_iter = PieceIterator::new();
-        for piece in piece_iter {
-            self.evaluate_piece(active_color, piece, board);
-        }
 
-        let mut opening_phase = self.gamephase;
-        if opening_phase > 24 {
-            // In case of early promotion
-            opening_phase = 24;
-        }
+        self.eval_piece_type(active_color, Piece::Pawn, board);
+        self.eval_piece_type(active_color, Piece::Knight, board);
+        self.eval_piece_type(active_color, Piece::Bishop, board);
+        self.eval_piece_type(active_color, Piece::Rook, board);
+        self.eval_piece_type(active_color, Piece::Queen, board);
+        self.eval_piece_type(active_color, Piece::King, board);
 
+        let opening_phase = self.gamephase.min(24);
         let endgame_phase = 24 - opening_phase;
-        eprintln!("Opening score: {}, Opening phase: {}, Endgame score: {}, Endgame phase: {}", self.opening_score, opening_phase, self.endgame_score, endgame_phase);
+
         (self.opening_score * opening_phase + self.endgame_score * endgame_phase) / 24
     }
 
-    fn evaluate_piece(
-        &mut self,
-        color: Color,
-        piece: Piece,
-        board: &Board,
-    ) {
-        // Calculate active player and oponent scores and increments for the passed peice
-        let (p_opening_score, p_endgame_score, p_gamephase) = self.evaluate_piece_position(color, piece, board);
-        let (o_opening_score, o_endgame_score, o_gamephase) = self.evaluate_piece_position(!color, piece, board);
+    fn eval_piece_type(&mut self, color: Color, piece: Piece, board: &Board) {
+        let piece_idx = piece.index();
+        let phase_inc = PHASE_INCREMENTS[piece_idx];
 
-        self.opening_score += p_opening_score - o_opening_score;
-        self.endgame_score += p_endgame_score - o_endgame_score;
-        self.gamephase += p_gamephase + o_gamephase;
-    }
+        // Active player
+        let player_bb = board.bb(color, piece);
+        let mut player_opening = 0;
+        let mut player_endgame = 0;
+        let mut player_count = 0;
 
-    fn evaluate_piece_position(
-        &self,
-        color: Color,
-        piece: Piece,
-        board: &Board
-    ) -> (i32, i32, i32) {
-        let mut opening_score = 0;
-        let mut endgame_score = 0;
-        let mut gamephase = 0;
-
-        let pieces = board.bb(color, piece);
-        let bitboard_iter = BitboardIterator::new(pieces);
+        let bitboard_iter = BitboardIterator::new(player_bb);
         for bit in bitboard_iter {
-            let square = match color {
-                Color::White => (7 - bit / 8) * 8 + bit % 8,
-                Color::Black => bit
-            };
-            opening_score += self.opening_tables[piece.index()][square as usize];
-            endgame_score += self.endgame_tables[piece.index()][square as usize];
-            gamephase += Self::phase_increment(piece);
-        }
-        (opening_score, endgame_score, gamephase)
-    }
+            let square = if color == Color::White { bit ^ 56 } else { bit };
 
-    fn phase_increment(piece: Piece) -> i32 {
-        match piece {
-            Piece::Pawn => 0,
-            Piece::Knight => 1,
-            Piece::Bishop => 1,
-            Piece::Rook => 2,
-            Piece::Queen => 4,
-            Piece::King => 0,
+            player_opening += OPENING_TABLES[piece_idx][square as usize];
+            player_endgame += ENDGAME_TABLES[piece_idx][square as usize];
+            player_count += phase_inc;
         }
+
+        // Opponent player
+        let opp_color = !color;
+        let opp_bb = board.bb(opp_color, piece);
+        let mut opp_opening = 0;
+        let mut opp_endgame = 0;
+        let mut opp_count = 0;
+
+        let bitboard_iter = BitboardIterator::new(opp_bb);
+        for bit in bitboard_iter {
+            let square = if opp_color == Color::White { bit ^ 56 } else { bit };
+
+            opp_opening += OPENING_TABLES[piece_idx][square as usize];
+            opp_endgame += ENDGAME_TABLES[piece_idx][square as usize];
+            opp_count += phase_inc;
+        }
+
+        self.opening_score += player_opening - opp_opening;
+        self.endgame_score += player_endgame - opp_endgame;
+        self.gamephase += (player_count + opp_count);
     }
 
     fn reset(&mut self) {
@@ -238,81 +115,23 @@ impl Evaluator {
         self.endgame_score = 0;
         self.gamephase = 0;
     }
-
-    /// --------------------------------------------
-    /// Functions to construct the Evaluator fields
-    /// --------------------------------------------
-    fn initialize_tables(phase: &Phase) -> [PST; PIECE_COUNT] {
-        let pst = [0; 64];
-        let mut tables = [pst; PIECE_COUNT];
-
-        let piece_iter = PieceIterator::new();
-        for piece in piece_iter {
-            tables[piece.index()] = Self::piece_square_table(piece, phase);
-        }
-
-        tables
-    }
-
-    fn piece_square_table(piece: Piece, phase: &Phase) -> PST {
-        match phase {
-            Phase::Opening => Self::opening_table(piece),
-            Phase::Endgame => Self::endgame_table(piece)
-        }
-    }
-
-    fn populate_table(table: PST, piece_value: i32) -> PST {
-        table.map(|x| x + piece_value)
-    }
-
-    fn opening_table(piece: Piece) -> PST {
-        let piece_value = Self::opening_value(piece);
-        let table = match piece {
-            Piece::Pawn => OPENING_PAWN_TABLE,
-            Piece::Knight => OPENING_KNIGHT_TABLE,
-            Piece::Bishop => OPENING_BISHOP_TABLE,
-            Piece::Rook => OPENING_ROOK_TABLE,
-            Piece::Queen => OPENING_QUEEN_TABLE,
-            Piece::King => OPENING_KING_TABLE,
-        };
-
-        Self::populate_table(table, piece_value)
-    }
-
-    fn endgame_table(piece: Piece) -> PST {
-        let piece_value = Self::endgame_value(piece);
-        let table = match piece {
-            Piece::Pawn => ENDGAME_PAWN_TABLE,
-            Piece::Knight => ENDGAME_KNIGHT_TABLE,
-            Piece::Bishop => ENDGAME_BISHOP_TABLE,
-            Piece::Rook => ENDGAME_ROOK_TABLE,
-            Piece::Queen => ENDGAME_QUEEN_TABLE,
-            Piece::King => ENDGAME_KING_TABLE,
-        };
-
-        Self::populate_table(table, piece_value)
-    }
-
-    fn opening_value(piece: Piece) -> i32 {
-        match piece {
-            Piece::Pawn => 82,
-            Piece::Knight => 337,
-            Piece::Bishop => 365,
-            Piece::Rook => 477,
-            Piece::Queen => 1025,
-            Piece::King => 0,
-        }
-    }
-
-    fn endgame_value(piece: Piece) -> i32 {
-        match piece {
-            Piece::Pawn => 94,
-            Piece::Knight => 281,
-            Piece::Bishop => 297,
-            Piece::Rook => 512,
-            Piece::Queen => 936,
-            Piece::King => 0,
-        }
-    }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eval() {
+        let mut evaluator = Evaluator::new();
+        let board = Board::new("rnbqkb1r/p1pp1ppp/1p3n2/4N3/4P3/8/PPPP1PPP/RNBQKB1R w KQkq - 0 4");
+
+        let start = Instant::now();
+
+        evaluator.evaluate(&board);
+
+        let duration = start.elapsed();
+        println!("Test took: {:?}", duration);
+
+    }
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,139 +1,318 @@
 use crate::board::Board;
-use crate::pieces::{Piece, Color};
-use crate::bitboard::BitboardIterator;
+use crate::bitboard::{SQUARES, BitboardIterator};
+use crate::pieces::{Piece, Color, PIECE_COUNT, PieceIterator};
 
-pub static PAWN_PIECE_SQUARE_TABLE: [i16; 64] = [
-    100, 100, 100, 100, 100, 100, 100, 100,
-    150, 150, 150, 150, 150, 150, 150, 150,
-    110, 110, 120, 130, 130, 120, 110, 110,
-    105, 105, 110, 125, 125, 110, 105, 105,
-    100, 100, 100, 120, 120, 100, 100, 100,
-    105,  95,  90, 100, 100,  90,  95, 105,
-    105, 110, 110,  80,  80, 110, 110, 105,
-    100, 100, 100, 100, 100, 100, 100, 100, 
+type PST = [i32; SQUARES as usize];
+
+const OPENING_PAWN_TABLE: PST = [
+      0,   0,   0,   0,   0,   0,  0,   0,
+     98, 134,  61,  95,  68, 126, 34, -11,
+     -6,   7,  26,  31,  65,  56, 25, -20,
+    -14,  13,   6,  21,  23,  12, 17, -23,
+    -27,  -2,  -5,  12,  17,   6, 10, -25,
+    -26,  -4,  -4, -10,   3,   3, 33, -12,
+    -35,  -1, -20, -23, -15,  24, 38, -22,
+      0,   0,   0,   0,   0,   0,  0,   0,
 ];
 
-pub static KNIGHT_PIECE_SQUARE_TABLE: [i16; 64] = [
-    270, 280, 290, 290, 290, 290, 280, 270,
-    280, 300, 320, 320, 320, 320, 300, 280,
-    290, 320, 330, 335, 335, 330, 320, 290,
-    290, 325, 335, 340, 340, 335, 325, 290,
-    290, 320, 335, 340, 340, 335, 320, 290,
-    290, 325, 330, 335, 335, 330, 325, 290,
-    280, 300, 320, 325, 325, 320, 300, 280,
-    270, 280, 290, 290, 290, 290, 280, 270,    
+const ENDGAME_PAWN_TABLE: PST = [
+      0,   0,   0,   0,   0,   0,   0,   0,
+    178, 173, 158, 134, 147, 132, 165, 187,
+     94, 100,  85,  67,  56,  53,  82,  84,
+     32,  24,  13,   5,  -2,   4,  17,  17,
+     13,   9,  -3,  -7,  -7,  -8,   3,  -1,
+      4,   7,  -6,   1,   0,  -5,  -1,  -8,
+     13,   8,   8,  10,  13,   0,   2,  -7,
+      0,   0,   0,   0,   0,   0,   0,   0,
 ];
 
-pub static BISHOP_PIECE_SQUARE_TABLE: [i16; 64] = [
-    310, 320, 320, 320, 320, 320, 320, 310,
-    320, 330, 330, 330, 330, 330, 330, 320,
-    320, 330, 335, 340, 340, 335, 330, 320,
-    320, 335, 335, 340, 340, 335, 335, 320,
-    320, 330, 340, 340, 340, 340, 330, 320,
-    320, 340, 340, 340, 340, 340, 340, 320,
-    320, 335, 330, 330, 330, 330, 335, 320,
-    310, 320, 320, 320, 320, 320, 320, 310,    
+const OPENING_KNIGHT_TABLE: PST = [
+    -167, -89, -34, -49,  61, -97, -15, -107,
+     -73, -41,  72,  36,  23,  62,   7,  -17,
+     -47,  60,  37,  65,  84, 129,  73,   44,
+      -9,  17,  19,  53,  37,  69,  18,   22,
+     -13,   4,  16,  13,  28,  19,  21,   -8,
+     -23,  -9,  12,  10,  19,  17,  25,  -16,
+     -29, -53, -12,  -3,  -1,  18, -14,  -19,
+    -105, -21, -58, -33, -17, -28, -19,  -23,
 ];
 
-pub static ROOK_PIECE_SQUARE_TABLE: [i16; 64] = [
-    500, 500, 500, 500, 500, 500, 500, 500,
-    505, 510, 510, 510, 510, 510, 510, 505,
-    495, 500, 500, 500, 500, 500, 500, 495,
-    495, 500, 500, 500, 500, 500, 500, 495,
-    495, 500, 500, 500, 500, 500, 500, 495,
-    495, 500, 500, 500, 500, 500, 500, 495,
-    495, 500, 500, 500, 500, 500, 500, 495,
-    500, 500, 500, 505, 505, 500, 500, 500,    
+const ENDGAME_KNIGHT_TABLE: PST = [
+    -58, -38, -13, -28, -31, -27, -63, -99,
+    -25,  -8, -25,  -2,  -9, -25, -24, -52,
+    -24, -20,  10,   9,  -1,  -9, -19, -41,
+    -17,   3,  22,  22,  22,  11,   8, -18,
+    -18,  -6,  16,  25,  16,  17,   4, -18,
+    -23,  -3,  -1,  15,  10,  -3, -20, -22,
+    -42, -20, -10,  -5,  -2, -20, -23, -44,
+    -29, -51, -23, -15, -22, -18, -50, -64,
 ];
 
-pub static QUEEN_PIECE_SQUARE_TABLE: [i16; 64] = [
-    880, 890, 890, 895, 895, 890, 890, 880,
-    890, 900, 900, 900, 900, 900, 900, 890,
-    890, 900, 905, 905, 905, 905, 900, 890,
-    895, 900, 905, 905, 905, 905, 900, 895,
-    900, 900, 905, 905, 905, 905, 900, 895,
-    890, 905, 905, 905, 905, 905, 900, 890,
-    890, 900, 905, 900, 900, 900, 900, 890,
-    880, 890, 890, 895, 895, 890, 890, 880,
+const OPENING_BISHOP_TABLE: PST = [
+    -29,   4, -82, -37, -25, -42,   7,  -8,
+    -26,  16, -18, -13,  30,  59,  18, -47,
+    -16,  37,  43,  40,  35,  50,  37,  -2,
+     -4,   5,  19,  50,  37,  37,   7,  -2,
+     -6,  13,  13,  26,  34,  12,  10,   4,
+      0,  15,  15,  15,  14,  27,  18,  10,
+      4,  15,  16,   0,   7,  21,  33,   1,
+    -33,  -3, -14, -21, -13, -12, -39, -21,
 ];
 
-pub static KING_OPENING_PIECE_SQUARE_TABLE: [i16; 64] = [
-    19970, 19960, 19960, 19950, 19950, 19960, 19960, 19970,
-    19970, 19960, 19960, 19950, 19950, 19960, 19960, 19970,
-    19970, 19960, 19960, 19950, 19950, 19960, 19960, 19970,
-    19970, 19960, 19960, 19950, 19950, 19960, 19960, 19970,
-    19980, 19970, 19970, 19960, 19960, 19970, 19970, 19980,
-    19990, 19980, 19980, 19980, 19980, 19980, 19980, 19990,
-    20020, 20020, 20000, 20000, 20000, 20000, 20020, 20020,
-    20020, 20030, 20010, 20000, 20000, 20010, 20030, 20020,
+const ENDGAME_BISHOP_TABLE: PST = [
+    -14, -21, -11,  -8, -7,  -9, -17, -24,
+     -8,  -4,   7, -12, -3, -13,  -4, -14,
+      2,  -8,   0,  -1, -2,   6,   0,   4,
+     -3,   9,  12,   9, 14,  10,   3,   2,
+     -6,   3,  13,  19,  7,  10,  -3,  -9,
+    -12,  -3,   8,  10, 13,   3,  -7, -15,
+    -14, -18,  -7,  -1,  4,  -9, -15, -27,
+    -23,  -9, -23,  -5, -9, -16,  -5, -17,
 ];
 
-pub static KING_ENDGAME_PIECE_SQUARE_TABLE: [i16; 64] = [
-    19950, 19960, 19970, 19980, 19980, 19970, 19960, 19950,
-    19970, 19980, 19990, 20000, 20000, 19990, 19980, 19970,
-    19970, 19990, 20020, 20030, 20030, 20020, 19990, 19970,
-    19970, 19990, 20030, 20040, 20040, 20030, 19990, 19970,
-    19970, 19990, 20030, 20040, 20040, 20030, 19990, 19970,
-    19970, 19990, 20020, 20030, 20030, 20020, 19990, 19970,
-    19970, 19970, 20000, 20000, 20000, 20000, 19970, 19970,
-    19950, 19970, 19970, 19970, 19970, 19970, 19970, 19950,
+const OPENING_ROOK_TABLE: PST = [
+     32,  42,  32,  51, 63,  9,  31,  43,
+     27,  32,  58,  62, 80, 67,  26,  44,
+     -5,  19,  26,  36, 17, 45,  61,  16,
+    -24, -11,   7,  26, 24, 35,  -8, -20,
+    -36, -26, -12,  -1,  9, -7,   6, -23,
+    -45, -25, -16, -17,  3,  0,  -5, -33,
+    -44, -16, -20,  -9, -1, 11,  -6, -71,
+    -19, -13,   1,  17, 16,  7, -37, -26,
 ];
 
-pub fn is_endgame(board: &Board) -> bool {
-    no_queens(board) || (has_queen_with_most_one_minor_piece(Color::White, board) && has_queen_with_most_one_minor_piece(Color::Black, board))
+const ENDGAME_ROOK_TABLE: PST = [
+    13, 10, 18, 15, 12,  12,   8,   5,
+    11, 13, 13, 11, -3,   3,   8,   3,
+     7,  7,  7,  5,  4,  -3,  -5,  -3,
+     4,  3, 13,  1,  2,   1,  -1,   2,
+     3,  5,  8,  4, -5,  -6,  -8, -11,
+    -4,  0, -5, -1, -7, -12,  -8, -16,
+    -6, -6,  0,  2, -9,  -9, -11,  -3,
+    -9,  2,  3, -1, -5, -13,   4, -20,
+];
+
+const OPENING_QUEEN_TABLE: PST = [
+    -28,   0,  29,  12,  59,  44,  43,  45,
+    -24, -39,  -5,   1, -16,  57,  28,  54,
+    -13, -17,   7,   8,  29,  56,  47,  57,
+    -27, -27, -16, -16,  -1,  17,  -2,   1,
+     -9, -26,  -9, -10,  -2,  -4,   3,  -3,
+    -14,   2, -11,  -2,  -5,   2,  14,   5,
+    -35,  -8,  11,   2,   8,  15,  -3,   1,
+     -1, -18,  -9,  10, -15, -25, -31, -50,
+];
+
+const ENDGAME_QUEEN_TABLE: PST = [
+     -9,  22,  22,  27,  27,  19,  10,  20,
+    -17,  20,  32,  41,  58,  25,  30,   0,
+    -20,   6,   9,  49,  47,  35,  19,   9,
+      3,  22,  24,  45,  57,  40,  57,  36,
+    -18,  28,  19,  47,  31,  34,  39,  23,
+    -16, -27,  15,   6,   9,  17,  10,   5,
+    -22, -23, -30, -16, -16, -23, -36, -32,
+    -33, -28, -22, -43,  -5, -32, -20, -41,
+];
+
+const OPENING_KING_TABLE: PST = [
+    -65,  23,  16, -15, -56, -34,   2,  13,
+     29,  -1, -20,  -7,  -8,  -4, -38, -29,
+     -9,  24,   2, -16, -20,   6,  22, -22,
+    -17, -20, -12, -27, -30, -25, -14, -36,
+    -49,  -1, -27, -39, -46, -44, -33, -51,
+    -14, -14, -22, -46, -44, -30, -15, -27,
+      1,   7,  -8, -64, -43, -16,   9,   8,
+    -15,  36,  12, -54,   8, -28,  24,  14,
+];
+
+const ENDGAME_KING_TABLE: PST = [
+    -74, -35, -18, -18, -11,  15,   4, -17,
+    -12,  17,  14,  17,  17,  38,  23,  11,
+     10,  17,  23,  15,  20,  45,  44,  13,
+     -8,  22,  24,  27,  26,  33,  26,   3,
+    -18,  -4,  21,  24,  27,  23,   9, -11,
+    -19,  -3,  11,  21,  23,  16,   7,  -9,
+    -27, -11,   4,  13,  14,   4,  -5, -17,
+    -53, -34, -21, -11, -28, -14, -24, -43
+];
+
+enum Phase {
+    Opening,
+    Endgame
 }
 
-fn no_queens(board: &Board) -> bool {
-    board.bb_piece(Piece::Queen) == 0
+pub struct Evaluator {
+    gamephase: i32,
+    opening_score: i32,
+    endgame_score: i32,
+    opening_tables: [PST; PIECE_COUNT],
+    endgame_tables: [PST; PIECE_COUNT],
 }
 
-fn has_queen_with_most_one_minor_piece(color: Color, board: &Board) -> bool {
-    let has_queen = board.bb(color, Piece::Queen) != 0;
-
-    if has_queen {
-        let minor_pieces = board.bb(color, Piece::Knight) | board.bb(color, Piece::Bishop);
-        let rooks = board.bb(color, Piece::Rook);
-        let has_no_other_pieces = minor_pieces | rooks == 0;
-        let has_one_minor_piece = minor_pieces.count_ones() <= 1 && rooks == 0;
-
-        return has_no_other_pieces || has_one_minor_piece;
-    }
-    true
-}
-
-pub fn evaluate(board: &Board) -> i16 {
-    let color = board.active_color();
-
-    let pawn_eval = eval_piece_position(color, Piece::Pawn, &PAWN_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::Pawn, &PAWN_PIECE_SQUARE_TABLE, board);
-    let knight_eval = eval_piece_position(color, Piece::Knight, &KNIGHT_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::Knight, &KNIGHT_PIECE_SQUARE_TABLE, board);
-    let bishop_eval = eval_piece_position(color, Piece::Bishop, &BISHOP_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::Bishop, &BISHOP_PIECE_SQUARE_TABLE, board);
-    let rook_eval = eval_piece_position(color, Piece::Rook, &ROOK_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::Rook, &ROOK_PIECE_SQUARE_TABLE, board);
-    let queen_eval = eval_piece_position(color, Piece::Queen, &QUEEN_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::Queen, &QUEEN_PIECE_SQUARE_TABLE, board);
-    
-    let king_eval = if is_endgame(board) {
-        eval_piece_position(color, Piece::King, &KING_ENDGAME_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::King, &KING_ENDGAME_PIECE_SQUARE_TABLE, board)
-    } else {
-        eval_piece_position(color, Piece::King, &KING_OPENING_PIECE_SQUARE_TABLE, board) - eval_piece_position(!color, Piece::King, &KING_OPENING_PIECE_SQUARE_TABLE, board)
-    };
-
-    pawn_eval + knight_eval + bishop_eval + rook_eval + queen_eval + king_eval
-}
-
-fn eval_piece_position(color:Color, piece: Piece, piece_square_table: &[i16; 64], board: &Board) -> i16 {
-    let pieces = board.bb(color, piece);
-
-    let mut score = 0;
-    let iter = BitboardIterator::new(pieces);
-    for square in iter {
-        match color {
-            Color::White => {
-                let index = (7 - square / 8) * 8 + square % 8;
-                score += piece_square_table[index as usize];
-            }
-            Color::Black => {
-                score += piece_square_table[square as usize];
-            }
+impl Evaluator {
+    pub fn new() -> Self {
+        Self {
+            gamephase: 0,
+            opening_score: 0,
+            endgame_score: 0,
+            opening_tables: Self::initialize_tables(&Phase::Opening),
+            endgame_tables: Self::initialize_tables(&Phase::Endgame),
         }
     }
-    score
+
+    /// ---------------------------------------------
+    /// Functions to perform evaluation of the board
+    /// ---------------------------------------------
+    pub fn evaluate(&mut self, board: &Board) -> i32 {
+        self.reset();
+
+        let active_color = board.active_color();
+        let piece_iter = PieceIterator::new();
+        for piece in piece_iter {
+            self.evaluate_piece(active_color, piece, board);
+        }
+
+        let mut opening_phase = self.gamephase;
+        if opening_phase > 24 {
+            // In case of early promotion
+            opening_phase = 24;
+        }
+
+        let endgame_phase = 24 - opening_phase;
+        eprintln!("Opening score: {}, Opening phase: {}, Endgame score: {}, Endgame phase: {}", self.opening_score, opening_phase, self.endgame_score, endgame_phase);
+        (self.opening_score * opening_phase + self.endgame_score * endgame_phase) / 24
+    }
+
+    fn evaluate_piece(
+        &mut self,
+        color: Color,
+        piece: Piece,
+        board: &Board,
+    ) {
+        // Calculate active player and oponent scores and increments for the passed peice
+        let (p_opening_score, p_endgame_score, p_gamephase) = self.evaluate_piece_position(color, piece, board);
+        let (o_opening_score, o_endgame_score, o_gamephase) = self.evaluate_piece_position(!color, piece, board);
+
+        self.opening_score += p_opening_score - o_opening_score;
+        self.endgame_score += p_endgame_score - o_endgame_score;
+        self.gamephase += p_gamephase + o_gamephase;
+    }
+
+    fn evaluate_piece_position(
+        &self,
+        color: Color,
+        piece: Piece,
+        board: &Board
+    ) -> (i32, i32, i32) {
+        let mut opening_score = 0;
+        let mut endgame_score = 0;
+        let mut gamephase = 0;
+
+        let pieces = board.bb(color, piece);
+        let bitboard_iter = BitboardIterator::new(pieces);
+        for bit in bitboard_iter {
+            let square = match color {
+                Color::White => (7 - bit / 8) * 8 + bit % 8,
+                Color::Black => bit
+            };
+            opening_score += self.opening_tables[piece.index()][square as usize];
+            endgame_score += self.endgame_tables[piece.index()][square as usize];
+            gamephase += Self::phase_increment(piece);
+        }
+        (opening_score, endgame_score, gamephase)
+    }
+
+    fn phase_increment(piece: Piece) -> i32 {
+        match piece {
+            Piece::Pawn => 0,
+            Piece::Knight => 1,
+            Piece::Bishop => 1,
+            Piece::Rook => 2,
+            Piece::Queen => 4,
+            Piece::King => 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.opening_score = 0;
+        self.endgame_score = 0;
+        self.gamephase = 0;
+    }
+
+    /// --------------------------------------------
+    /// Functions to construct the Evaluator fields
+    /// --------------------------------------------
+    fn initialize_tables(phase: &Phase) -> [PST; PIECE_COUNT] {
+        let pst = [0; 64];
+        let mut tables = [pst; PIECE_COUNT];
+
+        let piece_iter = PieceIterator::new();
+        for piece in piece_iter {
+            tables[piece.index()] = Self::piece_square_table(piece, phase);
+        }
+
+        tables
+    }
+
+    fn piece_square_table(piece: Piece, phase: &Phase) -> PST {
+        match phase {
+            Phase::Opening => Self::opening_table(piece),
+            Phase::Endgame => Self::endgame_table(piece)
+        }
+    }
+
+    fn populate_table(table: PST, piece_value: i32) -> PST {
+        table.map(|x| x + piece_value)
+    }
+
+    fn opening_table(piece: Piece) -> PST {
+        let piece_value = Self::opening_value(piece);
+        let table = match piece {
+            Piece::Pawn => OPENING_PAWN_TABLE,
+            Piece::Knight => OPENING_KNIGHT_TABLE,
+            Piece::Bishop => OPENING_BISHOP_TABLE,
+            Piece::Rook => OPENING_ROOK_TABLE,
+            Piece::Queen => OPENING_QUEEN_TABLE,
+            Piece::King => OPENING_KING_TABLE,
+        };
+
+        Self::populate_table(table, piece_value)
+    }
+
+    fn endgame_table(piece: Piece) -> PST {
+        let piece_value = Self::endgame_value(piece);
+        let table = match piece {
+            Piece::Pawn => ENDGAME_PAWN_TABLE,
+            Piece::Knight => ENDGAME_KNIGHT_TABLE,
+            Piece::Bishop => ENDGAME_BISHOP_TABLE,
+            Piece::Rook => ENDGAME_ROOK_TABLE,
+            Piece::Queen => ENDGAME_QUEEN_TABLE,
+            Piece::King => ENDGAME_KING_TABLE,
+        };
+
+        Self::populate_table(table, piece_value)
+    }
+
+    fn opening_value(piece: Piece) -> i32 {
+        match piece {
+            Piece::Pawn => 82,
+            Piece::Knight => 337,
+            Piece::Bishop => 365,
+            Piece::Rook => 477,
+            Piece::Queen => 1025,
+            Piece::King => 0,
+        }
+    }
+
+    fn endgame_value(piece: Piece) -> i32 {
+        match piece {
+            Piece::Pawn => 94,
+            Piece::Knight => 281,
+            Piece::Bishop => 297,
+            Piece::Rook => 512,
+            Piece::Queen => 936,
+            Piece::King => 0,
+        }
+    }
 }
+

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -1,4 +1,3 @@
-use std::num::Wrapping;
 use rand::prelude::ThreadRng;
 use rand::RngCore;
 
@@ -233,7 +232,7 @@ impl Magic {
         }
 
         // Testing magic numbers
-        for random_count in 0..1000000 {
+        for _random_count in 0..1000000 {
             let magic: u64 = Self::gen_random_number();
 
             // Reset used attacks

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -3,8 +3,7 @@ use crate::bitboard::{Bitboard, BitboardIterator, BitboardOperations, RANK_2, RA
 use crate::lookup::LookupTable;
 use crate::pieces::{Piece, Color, PromotionPieceIterator};
 use crate::moves::{Move, MoveType, NORTH, EAST, SOUTH, WEST};
-use crate::square::{Square, C1, C8, E1, E8, G1, G8, square_to_rank_file};
-use crate::util::print_bitboard;
+use crate::square::{Square, C1, C8, E1, E8, G1, G8};
 
 pub struct MoveGenerator {
     pub lookup: LookupTable

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -86,12 +86,12 @@ impl std::fmt::Display for Color {
 impl Piece {
     pub fn index(&self) -> usize {
         match self {
-            Piece::Pawn => 5,
-            Piece::Knight => 4,
-            Piece::Bishop => 3,
-            Piece::Rook => 2,
-            Piece::Queen => 1,
-            Piece::King => 0,
+            Piece::Pawn => 0,
+            Piece::Knight => 1,
+            Piece::Bishop => 2,
+            Piece::Rook => 3,
+            Piece::Queen => 4,
+            Piece::King => 5,
         }
     }
 }

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -209,6 +209,15 @@ impl IndexMut<Color> for [Bitboard; COLOR_COUNT] {
     }
 }
 
+impl Color {
+    pub fn index(&self) -> usize {
+        match self {
+            Color::White => 0,
+            Color::Black => 1,
+        }
+    }
+}
+
 impl std::ops::Not for Color {
     type Output = Color;
 

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -1,4 +1,4 @@
-use std::ops::{Index, IndexMut, Not};
+use std::ops::{Index, IndexMut};
 use crate::bitboard::Bitboard;
 
 
@@ -205,15 +205,6 @@ impl IndexMut<Color> for [Bitboard; COLOR_COUNT] {
         match color {
             Color::White => &mut self[0],
             Color::Black => &mut self[1],
-        }
-    }
-}
-
-impl Color {
-    pub fn index(&self) -> usize {
-        match self {
-            Color::White => 0,
-            Color::Black => 1,
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::move_gen::MoveGenerator;
-use crate::eval::evaluate;
+use crate::eval::Evaluator;
 use crate::board::Board;
 use crate::moves::{Move, MoveType};
 use crate::transposition::{TranspositionTable, Bounds};
@@ -17,6 +17,7 @@ const MATE_VALUE: i32 = std::i32::MAX - 1;
 
 pub struct Searcher {
     move_gen: MoveGenerator,
+    evaluator: Evaluator,
     zobrist: ZobristTable,
     transposition_table: TranspositionTable,
     repetition_table: RepetitionTable,
@@ -26,6 +27,7 @@ impl Searcher {
     pub fn new() -> Self {
         Self {
             move_gen: MoveGenerator::new(),
+            evaluator: Evaluator::new(),
             zobrist: ZobristTable::new(),
             transposition_table: TranspositionTable::new(),
             repetition_table: RepetitionTable::new(),
@@ -135,7 +137,7 @@ impl Searcher {
             return -MATE_VALUE as i32;
         }
 
-        let stand_pat = evaluate(board) as i32;
+        let stand_pat = self.evaluator.evaluate(board) as i32;
         if stand_pat >= beta {
             return beta;
         }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,7 +1,6 @@
 use crate::board::Board;
 use crate::search::Searcher;
 use crate::move_gen::MoveGenerator;
-use crate::util::print_board;
 
 pub struct Flounder {
     board: Board,


### PR DESCRIPTION
## Description
- Implemented the PeSTO evaluation function specified here: https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function
- Cleaned up some unused imports

## Performance
This brought the time to evaluate a single position down to ~5us from ~30us with the previous PST eval function. However, the time to run the tests (using this as a performance proxy for now) went up to ~110s from 60s. 

I believe this is due to alpha-beta pruning pruning less branches because of the new eval. Going to look on improving the search next which should bring this down. I'll add a better way to measure performance as well.